### PR TITLE
Make the gemspec more canonical

### DIFF
--- a/no_peeping_toms.gemspec
+++ b/no_peeping_toms.gemspec
@@ -12,9 +12,7 @@ Gem::Specification.new do |s|
   s.summary     = %q{Disables observers during testing, allowing you to write model tests that are completely decoupled from the observer.}
   s.description = %q{Disables observers during testing, allowing you to write model tests that are completely decoupled from the observer.}
 
-  s.files         = `git ls-files`.split("\n")
-  s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
-  s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
+  s.files         = Dir["*.rdoc", "{lib,spec}/**/*"]
   s.require_paths = ["lib"]
 
   s.add_runtime_dependency 'activerecord', '>=3.0.0'


### PR DESCRIPTION
Fixed the gemspec to deal with environments where git isn't in the environment

E.g. Bundler looks at the gemspec when running in development mode under
Passenger. If git isn't in Passenger's environment path, an app blows up.
