### PR TITLE
Depend on ActiveSupport 3.2, remove deprecated Instancemethods

### DIFF
--- a/lib/no_peeping_toms.rb
+++ b/lib/no_peeping_toms.rb
@@ -45,32 +45,30 @@ module NoPeepingToms
     end
   end
 
-  module InstanceMethods
-    # Overrides ActiveRecord#define_callbacks so that observers are only called
-    # when enabled.
-    #
-    # This is a bit yuck being a protected method, but appears to be the cleanest
-    # way so far
-    def define_callbacks_with_enabled_check(klass)
-      observer = self
-      observer_name = observer.class.name.underscore.gsub('/', '__')
+  # Overrides ActiveRecord#define_callbacks so that observers are only called
+  # when enabled.
+  #
+  # This is a bit yuck being a protected method, but appears to be the cleanest
+  # way so far
+  def define_callbacks_with_enabled_check(klass)
+    observer = self
+    observer_name = observer.class.name.underscore.gsub('/', '__')
 
-      ActiveRecord::Callbacks::CALLBACKS.each do |callback|
-        next unless respond_to?(callback)
-        callback_meth = :"_notify_#{observer_name}_for_#{callback}"
-        unless klass.respond_to?(callback_meth)
-          klass.send(:define_method, callback_meth) do
-            observer.send(callback, self) if observer.observer_enabled?
-          end
-          klass.send(callback, callback_meth)
+    ActiveRecord::Callbacks::CALLBACKS.each do |callback|
+      next unless respond_to?(callback)
+      callback_meth = :"_notify_#{observer_name}_for_#{callback}"
+      unless klass.respond_to?(callback_meth)
+        klass.send(:define_method, callback_meth) do
+          observer.send(callback, self) if observer.observer_enabled?
         end
+        klass.send(callback, callback_meth)
       end
     end
+  end
 
-    # Determines whether this observer should be run
-    def observer_enabled?
-      self.class.observer_enabled?(self)
-    end
+  # Determines whether this observer should be run
+  def observer_enabled?
+    self.class.observer_enabled?(self)
   end
 end
 

--- a/no_peeping_toms.gemspec
+++ b/no_peeping_toms.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_runtime_dependency 'activerecord', '>=3.0.0'
-  s.add_runtime_dependency 'activesupport', '>=3.0.0'
+  s.add_runtime_dependency 'activesupport', '>=3.2.0'
 
   s.add_development_dependency 'rspec', '~>2.5'
   s.add_development_dependency 'sqlite3'


### PR DESCRIPTION
The `InstanceMethods` is deprecated in ActiveSupport 3.2.

This PR updates it accordingly.

The workaround is to use my branch:

`gem 'no_peeping_toms', :git => 'git://github.com/dnagir/no-peeping-toms.git', :branch => 'activesupport-3.2'`
